### PR TITLE
Use Integer instead of Fixnum in EntityHandler.rb

### DIFF
--- a/lib/BaseClass/EntityHandler.rb
+++ b/lib/BaseClass/EntityHandler.rb
@@ -76,8 +76,8 @@ module LeanTesting
 		#	SDKInvalidArgException if provided id param is not an integer.
 		#
 		def find(id)
-			if !id.is_a? Fixnum
-				raise SDKInvalidArgException, '`id` must be of type Fixnum'
+			if !id.is_a? Integer
+				raise SDKInvalidArgException, '`id` must be of type Integer'
 			end
 		end
 


### PR DESCRIPTION
To avoid the ruby 2.4.0+ deprecation warning: `warning: constant ::Fixnum is deprecated`